### PR TITLE
When not specified in `gentypeconfig`, read the `module` type from `p…

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,6 @@
 # master
 - Give a warning when attempting to export a GADT type (unless it's already an opaque export), and export it as an opaque type.
+- When not specified in `gentypeconfig`, read the `module` type from `package-specs`.
 
 # 3.44.0
 - Fix issue with non-recursive types inside modules when the type name is already in scope (See https://github.com/reason-association/genType/issues/492).

--- a/src/Config_.re
+++ b/src/Config_.re
@@ -171,7 +171,7 @@ let getDebug = json =>
   | _ => ()
   };
 
-let readConfig = (~bsVersion, ~getConfigFile, ~getBsConfigFile, ~namespace) => {
+let readConfig = (~bsVersion, ~getBsConfigFile, ~namespace) => {
   let fromJson = (~packageSpecsModule, json) => {
     let languageString = json |> getString("language");
     let moduleString = json |> getStringOption("module");
@@ -357,8 +357,8 @@ let readConfig = (~bsVersion, ~getConfigFile, ~getBsConfigFile, ~namespace) => {
         };
       let config =
         switch (map |> String_map.find_opt("gentypeconfig")) {
-        | Some(jsonGenFlowConfig) =>
-          jsonGenFlowConfig |> fromJson(~packageSpecsModule)
+        | Some(jsonGenTypeConfig) =>
+          jsonGenTypeConfig |> fromJson(~packageSpecsModule)
         | _ => default
         };
       let config =
@@ -389,22 +389,11 @@ let readConfig = (~bsVersion, ~getConfigFile, ~getBsConfigFile, ~namespace) => {
       config;
     | _ => default
     };
-  switch (getConfigFile()) {
-  | Some(configFile) =>
-    try(
-      configFile
-      |> Ext_json_parse.parse_json_from_file
-      |> fromJson(~packageSpecsModule=None)
-    ) {
+  switch (getBsConfigFile()) {
+  | Some(bsConfigFile) =>
+    try(bsConfigFile |> Ext_json_parse.parse_json_from_file |> fromBsConfig) {
     | _ => default
     }
-  | None =>
-    switch (getBsConfigFile()) {
-    | Some(bsConfigFile) =>
-      try(bsConfigFile |> Ext_json_parse.parse_json_from_file |> fromBsConfig) {
-      | _ => default
-      }
-    | None => default
-    }
+  | None => default
   };
 };

--- a/src/Paths.re
+++ b/src/Paths.re
@@ -101,10 +101,6 @@ let getCmtFile = cmt => {
   cmtFile;
 };
 
-let getConfigFile = () => {
-  let gentypeconfig = concat(projectRoot^, "gentypeconfig.json");
-  gentypeconfig |> Sys.file_exists ? Some(gentypeconfig) : None;
-};
 let getBsConfigFile = () => {
   let bsconfig = concat(projectRoot^, "bsconfig.json");
   bsconfig |> Sys.file_exists ? Some(bsconfig) : None;
@@ -145,5 +141,5 @@ let relativePathFromBsLib = fileName =>
 
 let readConfig = (~bsVersion, ~namespace) => {
   setProjectRoot();
-  Config.readConfig(~bsVersion, ~getConfigFile, ~getBsConfigFile, ~namespace);
+  Config.readConfig(~bsVersion, ~getBsConfigFile, ~namespace);
 };


### PR DESCRIPTION
…ackage-specs`.

Fixes https://github.com/rescript-association/genType/issues/505