### PR TITLE
Remove legacy code for bs-platform before 8.2.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,8 @@
 # master
 - Give a warning when attempting to export a GADT type (unless it's already an opaque export), and export it as an opaque type.
 - When not specified in `gentypeconfig`, read the `module` type from `package-specs`.
+- Only support bs-platform `8.2.0` or newer.
+
 
 # 3.44.0
 - Fix issue with non-recursive types inside modules when the type name is already in scope (See https://github.com/reason-association/genType/issues/492).

--- a/src/Config_.re
+++ b/src/Config_.re
@@ -22,7 +22,6 @@ type config = {
   bsBlockPath: option(string),
   bsCurryPath: option(string),
   bsDependencies: list(string),
-  bsPlatformLibExtension: string,
   mutable emitCreateBucklescriptBlock: bool,
   mutable emitFlowAny: bool,
   mutable emitImportCurry: bool,
@@ -35,23 +34,17 @@ type config = {
   importPath,
   language,
   module_,
-  modulesAsObjects: bool,
   namespace: option(string),
   propTypes: bool,
   reasonReactPath: string,
-  recordsAsObjects: bool,
   shimsMap: ModuleNameMap.t(ModuleName.t),
   sources: option(Ext_json_types.t),
-  useUnboxedAnnotations: bool,
-  variantsAsObjects: bool,
-  variantHashesAsStrings: bool,
 };
 
 let default = {
   bsBlockPath: None,
   bsCurryPath: None,
   bsDependencies: [],
-  bsPlatformLibExtension: ".js",
   emitCreateBucklescriptBlock: false,
   emitFlowAny: false,
   emitImportCurry: false,
@@ -64,16 +57,11 @@ let default = {
   importPath: Relative,
   language: Flow,
   module_: ES6,
-  modulesAsObjects: false,
   namespace: None,
   propTypes: false,
   reasonReactPath: "reason-react/src/ReasonReact.js",
-  recordsAsObjects: false,
   shimsMap: ModuleNameMap.empty,
   sources: None,
-  useUnboxedAnnotations: false,
-  variantsAsObjects: false,
-  variantHashesAsStrings: false,
 };
 
 let bsPlatformLib = (~config) =>
@@ -82,17 +70,16 @@ let bsPlatformLib = (~config) =>
   | CommonJS => "bs-platform/lib/js"
   };
 
+let bsPlatformLibExtension = ".js";
 let getBsBlockPath = (~config) =>
   switch (config.bsBlockPath) {
-  | None =>
-    bsPlatformLib(~config) ++ "/block" ++ config.bsPlatformLibExtension
+  | None => bsPlatformLib(~config) ++ "/block" ++ bsPlatformLibExtension
   | Some(s) => s
   };
 
 let getBsCurryPath = (~config) =>
   switch (config.bsCurryPath) {
-  | None =>
-    bsPlatformLib(~config) ++ "/curry" ++ config.bsPlatformLibExtension
+  | None => bsPlatformLib(~config) ++ "/curry" ++ bsPlatformLibExtension
   | Some(s) => s
   };
 
@@ -253,40 +240,6 @@ let readConfig = (~bsVersion, ~getBsConfigFile, ~namespace) => {
         }
       };
     let (v1, v2, v3) = bsVersion;
-    let modulesAsObjects = {
-      switch (v1) {
-      | 5 => bsVersion >= (5, 2, 0)
-      | 6 => bsVersion >= (6, 2, 0)
-      | _ => v1 > 6
-      };
-    };
-    let recordsAsObjects = {
-      switch (v1) {
-      | 5 => bsVersion >= (5, 3, 0)
-      | 6 => bsVersion >= (6, 3, 0)
-      | _ => v1 > 6
-      };
-    };
-    let variantsAsObjects = {
-      switch (v1) {
-      | _ => v1 >= 8
-      };
-    };
-    let variantHashesAsStrings = {
-      bsVersion >= (8, 2, 0);
-    };
-    let useUnboxedAnnotations = {
-      switch (v1) {
-      | 7 => bsVersion > (7, 0, 1)
-      | _ => v1 > 7
-      };
-    };
-    let bsPlatformLibExtension =
-      if (v1 >= 9 && v2 == 0 && v3 == 0 && module_ == ES6) {
-        ".mjs";
-      } else {
-        ".js";
-      };
     if (Debug.config^) {
       Log_.item("Project root: %s\n", projectRoot^);
       if (bsbProjectRoot^ != projectRoot^) {
@@ -338,7 +291,6 @@ let readConfig = (~bsVersion, ~getBsConfigFile, ~namespace) => {
       bsBlockPath,
       bsCurryPath,
       bsDependencies,
-      bsPlatformLibExtension,
       emitCreateBucklescriptBlock: false,
       emitFlowAny: false,
       emitImportCurry: false,
@@ -351,16 +303,11 @@ let readConfig = (~bsVersion, ~getBsConfigFile, ~namespace) => {
       importPath,
       language,
       module_,
-      modulesAsObjects,
       namespace,
       propTypes,
       reasonReactPath,
-      recordsAsObjects,
       shimsMap,
       sources,
-      useUnboxedAnnotations,
-      variantsAsObjects,
-      variantHashesAsStrings,
     };
   };
   switch (getBsConfigFile()) {

--- a/src/EmitJs.re
+++ b/src/EmitJs.re
@@ -940,11 +940,7 @@ let emitVariantTables = (~config, ~emitters, variantTables) => {
            let js = case.labelJS |> labelJSToString(~alwaysQuotes=!toJS);
            let re =
              case.label
-             |> Runtime.emitVariantLabel(
-                  ~comment=false,
-                  ~config,
-                  ~polymorphic=variantC.polymorphic,
-                );
+             |> Runtime.emitVariantLabel(~polymorphic=variantC.polymorphic);
            toJS
              ? (re |> EmitText.quotesIfRequired) ++ ": " ++ js
              : js ++ ": " ++ re;

--- a/src/EmitText.re
+++ b/src/EmitText.re
@@ -101,6 +101,4 @@ let addComment = (~comment, x) => "\n/* " ++ comment ++ " */\n  " ++ x;
 let arrayAccess = (~index, value) =>
   value ++ "[" ++ string_of_int(index) ++ "]";
 
-let arraySlice = value => value ++ ".slice()";
-
 let fieldAccess = (~label, value) => value ++ "." ++ label;

--- a/src/EmitType.re
+++ b/src/EmitType.re
@@ -332,11 +332,9 @@ let rec renderType =
              : [
                  case.labelJS
                  |> labelJSToString
-                 |> field(~name=Runtime.jsVariantTag(~config, ~polymorphic)),
+                 |> field(~name=Runtime.jsVariantTag(~polymorphic)),
                  typeRendered
-                 |> field(
-                      ~name=Runtime.jsVariantValue(~config, ~polymorphic),
-                    ),
+                 |> field(~name=Runtime.jsVariantValue(~polymorphic)),
                ]
                |> fields;
          });

--- a/src/ExportModule.re
+++ b/src/ExportModule.re
@@ -142,7 +142,7 @@ let emitAllModuleItems =
   emitters
   |> rev_fold(
        (moduleName, exportModuleItem, emitters) => {
-         let {typeForValue, typeForType, needsConversion} =
+         let {typeForType, needsConversion} =
            M(exportModuleItem) |> exportModuleValueToType(~config);
          if (Debug.codeItems^) {
            Log_.item(
@@ -155,18 +155,9 @@ let emitAllModuleItems =
            emitters;
          } else {
            let emittedModuleItem =
-             config.modulesAsObjects
-               ? ModuleName.forInnerModule(
-                   ~fileName,
-                   ~innerModuleName=moduleName,
-                 )
-                 |> ModuleName.toString
-               : typeForValue
-                 |> EmitType.typeToString(
-                      ~config={...config, language: Flow} /* abuse type to print object */,
-                      ~typeNameIsInterface=_ =>
-                      false
-                    );
+             ModuleName.forInnerModule(~fileName, ~innerModuleName=moduleName)
+             |> ModuleName.toString;
+
            emittedModuleItem
            |> EmitType.emitExportConst(
                 ~config,

--- a/src/Runtime.rei
+++ b/src/Runtime.rei
@@ -4,15 +4,13 @@ type recordGen;
 
 type recordValue;
 
-type moduleItemGen;
-
 type moduleItem;
 
 type moduleAccessPath =
   | Root(string)
   | Dot(moduleAccessPath, moduleItem);
 
-let accessVariant: (~config: config, ~index: int, string) => string;
+let accessVariant: (~index: int, string) => string;
 
 let checkMutableObjectField: (~previousName: string, ~name: string) => bool;
 
@@ -21,30 +19,19 @@ let default: string;
 
 let emitModuleAccessPath: (~config: config, moduleAccessPath) => string;
 
-let emitJSVariantGetLabel:
-  (~config: config, ~polymorphic: bool, string) => string;
+let emitJSVariantGetLabel: (~polymorphic: bool, string) => string;
 
-let emitJSVariantGetPayload:
-  (~config: config, ~polymorphic: bool, string) => string;
+let emitJSVariantGetPayload: (~polymorphic: bool, string) => string;
 
 let emitJSVariantWithPayload:
-  (~config: config, ~label: string, ~polymorphic: bool, string) => string;
+  (~label: string, ~polymorphic: bool, string) => string;
 
-let emitVariantGetLabel:
-  (~config: config, ~polymorphic: bool, string) => string;
+let emitVariantGetLabel: (~polymorphic: bool, string) => string;
 
 let emitVariantGetPayload:
-  (
-    ~config: config,
-    ~inlineRecord: bool,
-    ~numArgs: int,
-    ~polymorphic: bool,
-    string
-  ) =>
-  string;
+  (~inlineRecord: bool, ~numArgs: int, ~polymorphic: bool, string) => string;
 
-let emitVariantLabel:
-  (~comment: bool=?, ~config: config, ~polymorphic: bool, string) => string;
+let emitVariantLabel: (~polymorphic: bool, string) => string;
 
 let emitVariantWithPayload:
   (
@@ -60,9 +47,7 @@ let isMutableObjectField: string => bool;
 
 let mangleObjectField: string => string;
 
-let moduleItemGen: unit => moduleItemGen;
-
-let newModuleItem: (~name: string, moduleItemGen) => moduleItem;
+let newModuleItem: (~name: string) => moduleItem;
 
 let newRecordValue: (~unboxed: bool, recordGen) => recordValue;
 
@@ -70,6 +55,6 @@ let recordGen: unit => recordGen;
 
 let recordValueToString: recordValue => string;
 
-let jsVariantTag: (~config: config, ~polymorphic: bool) => string;
+let jsVariantTag: (~polymorphic: bool) => string;
 
-let jsVariantValue: (~config: config, ~polymorphic: bool) => string;
+let jsVariantValue: (~polymorphic: bool) => string;

--- a/src/TranslateSignature.re
+++ b/src/TranslateSignature.re
@@ -133,14 +133,7 @@ and translateModuleTypeDeclaration =
   };
 }
 and translateSignatureItem =
-    (
-      ~config,
-      ~outputFileRelative,
-      ~resolver,
-      ~moduleItemGen,
-      ~typeEnv,
-      signatureItem,
-    )
+    (~config, ~outputFileRelative, ~resolver, ~typeEnv, signatureItem)
     : Translation.t =>
   switch (signatureItem) {
   | {Typedtree.sig_desc: Typedtree.Tsig_type(recFlag, typeDeclarations)} => {
@@ -151,7 +144,7 @@ and translateSignatureItem =
         |> TranslateTypeDeclarations.translateTypeDeclarations(
              ~config,
              ~outputFileRelative,
-             ~recursive=recFlag==Recursive,
+             ~recursive=recFlag == Recursive,
              ~resolver,
              ~typeEnv,
            ),
@@ -171,8 +164,7 @@ and translateSignatureItem =
          );
     } else {
       let moduleItem =
-        moduleItemGen
-        |> Runtime.newModuleItem(~name=valueDescription.val_id |> Ident.name);
+        Runtime.newModuleItem(~name=valueDescription.val_id |> Ident.name);
       typeEnv |> TypeEnv.updateModuleItem(~moduleItem);
       valueDescription
       |> translateSignatureValue(
@@ -194,10 +186,7 @@ and translateSignatureItem =
 
   | {Typedtree.sig_desc: Typedtree.Tsig_modtype(moduleTypeDeclaration)} =>
     let moduleItem =
-      moduleItemGen
-      |> Runtime.newModuleItem(
-           ~name=moduleTypeDeclaration.mtd_id |> Ident.name,
-         );
+      Runtime.newModuleItem(~name=moduleTypeDeclaration.mtd_id |> Ident.name);
     typeEnv |> TypeEnv.updateModuleItem(~moduleItem);
     moduleTypeDeclaration
     |> translateModuleTypeDeclaration(
@@ -238,14 +227,12 @@ and translateSignature =
   if (Debug.translation^) {
     Log_.item("Translate Signature\n");
   };
-  let moduleItemGen = Runtime.moduleItemGen();
   signature.Typedtree.sig_items
   |> List.map(
        translateSignatureItem(
          ~config,
          ~outputFileRelative,
          ~resolver,
-         ~moduleItemGen,
          ~typeEnv,
        ),
      );

--- a/src/TranslateSignatureFromTypes.re
+++ b/src/TranslateSignatureFromTypes.re
@@ -85,7 +85,6 @@ and translateSignatureItemFromTypes =
       ~config,
       ~outputFileRelative,
       ~resolver,
-      ~moduleItemGen,
       ~typeEnv,
       signatureItem: Types.signature_item,
     )
@@ -106,8 +105,7 @@ and translateSignatureItemFromTypes =
     }
 
   | Types.Sig_module(id, moduleDeclaration, _) =>
-    let moduleItem =
-      moduleItemGen |> Runtime.newModuleItem(~name=id |> Ident.name);
+    let moduleItem = Runtime.newModuleItem(~name=id |> Ident.name);
     typeEnv |> TypeEnv.updateModuleItem(~moduleItem);
     moduleDeclaration
     |> translateModuleDeclarationFromTypes(
@@ -123,7 +121,7 @@ and translateSignatureItemFromTypes =
     if (Debug.translation^) {
       Log_.item("Translate Sig Value %s\n", name);
     };
-    let moduleItem = moduleItemGen |> Runtime.newModuleItem(~name);
+    let moduleItem = Runtime.newModuleItem(~name);
     typeEnv |> TypeEnv.updateModuleItem(~nameOpt=Some(name), ~moduleItem);
     if (val_attributes |> Annotation.fromAttributes(~loc=val_loc) == GenType) {
       name
@@ -167,14 +165,12 @@ and translateSignatureFromTypes =
   if (Debug.translation^) {
     Log_.item("Translate Types.signature\n");
   };
-  let moduleItemGen = Runtime.moduleItemGen();
   signature
   |> List.map(
        translateSignatureItemFromTypes(
          ~config,
          ~outputFileRelative,
          ~resolver,
-         ~moduleItemGen,
          ~typeEnv,
        ),
      );

--- a/src/TranslateStructure.re
+++ b/src/TranslateStructure.re
@@ -74,7 +74,6 @@ and addAnnotationsToFields =
     let (nameJS, nameRE) =
       TranslateTypeDeclarations.renameRecordField(
         ~attributes=expr.exp_attributes,
-        ~config,
         ~nameRE=field.nameRE,
       );
     ([{...field, nameJS, nameRE}, ...nextFields1], types1);
@@ -133,7 +132,6 @@ let translateValueBinding =
       ~config,
       ~outputFileRelative,
       ~resolver,
-      ~moduleItemGen,
       ~typeEnv,
       {Typedtree.vb_attributes, vb_expr, vb_pat},
     )
@@ -145,7 +143,7 @@ let translateValueBinding =
     if (Debug.translation^) {
       Log_.item("Translate Value Binding %s\n", name);
     };
-    let moduleItem = moduleItemGen |> Runtime.newModuleItem(~name);
+    let moduleItem = Runtime.newModuleItem(~name);
     typeEnv |> TypeEnv.updateModuleItem(~nameOpt=Some(name), ~moduleItem);
 
     if (vb_attributes
@@ -221,7 +219,6 @@ let rec translateModuleBinding =
           ~outputFileRelative,
           ~resolver,
           ~typeEnv,
-          ~moduleItemGen,
           {mb_id, mb_expr, mb_attributes}: Typedtree.module_binding,
         )
         : Translation.t => {
@@ -229,7 +226,7 @@ let rec translateModuleBinding =
   if (Debug.translation^) {
     Log_.item("Translate Module Binding %s\n", name);
   };
-  let moduleItem = moduleItemGen |> Runtime.newModuleItem(~name);
+  let moduleItem = Runtime.newModuleItem(~name);
   typeEnv |> TypeEnv.updateModuleItem(~moduleItem);
   let typeEnv = typeEnv |> TypeEnv.newModule(~name);
 
@@ -379,14 +376,7 @@ let rec translateModuleBinding =
   };
 }
 and translateStructureItem =
-    (
-      ~config,
-      ~outputFileRelative,
-      ~resolver,
-      ~moduleItemGen,
-      ~typeEnv,
-      structItem,
-    )
+    (~config, ~outputFileRelative, ~resolver, ~typeEnv, structItem)
     : Translation.t =>
   switch (structItem) {
   | {Typedtree.str_desc: Typedtree.Tstr_type(recFlag, typeDeclarations)} => {
@@ -410,7 +400,6 @@ and translateStructureItem =
            ~config,
            ~outputFileRelative,
            ~resolver,
-           ~moduleItemGen,
            ~typeEnv,
          ),
        )
@@ -433,7 +422,6 @@ and translateStructureItem =
          ~outputFileRelative,
          ~resolver,
          ~typeEnv,
-         ~moduleItemGen,
        )
 
   | {Typedtree.str_desc: Tstr_modtype(moduleTypeDeclaration)} =>
@@ -453,7 +441,6 @@ and translateStructureItem =
            ~outputFileRelative,
            ~resolver,
            ~typeEnv,
-           ~moduleItemGen,
          ),
        )
     |> Translation.combine
@@ -487,7 +474,6 @@ and translateStructureItem =
          ~config,
          ~outputFileRelative,
          ~resolver,
-         ~moduleItemGen,
          ~typeEnv,
        )
 
@@ -529,7 +515,6 @@ and translateStructure =
   if (Debug.translation^) {
     Log_.item("Translate Structure\n");
   };
-  let moduleItemGen = Runtime.moduleItemGen();
   structure.Typedtree.str_items
   |> removeValueBindingDuplicates
   |> List.map(structItem =>
@@ -538,7 +523,6 @@ and translateStructure =
             ~config,
             ~outputFileRelative,
             ~resolver,
-            ~moduleItemGen,
             ~typeEnv,
           )
      );

--- a/src/TranslateTypeExprFromTypes.re
+++ b/src/TranslateTypeExprFromTypes.re
@@ -89,22 +89,18 @@ let translateConstr =
   | (["Pervasives", "ref"], [paramTranslation]) => {
       dependencies: paramTranslation.dependencies,
       type_:
-        if (config.recordsAsObjects) {
-          Object(
-            Closed,
-            [
-              {
-                mutable_: Mutable,
-                nameJS: "contents",
-                nameRE: "contents",
-                optional: Mandatory,
-                type_: paramTranslation.type_,
-              },
-            ],
-          );
-        } else {
-          Tuple([paramTranslation.type_]);
-        },
+        Object(
+          Closed,
+          [
+            {
+              mutable_: Mutable,
+              nameJS: "contents",
+              nameRE: "contents",
+              optional: Mandatory,
+              type_: paramTranslation.type_,
+            },
+          ],
+        ),
     }
 
   | (
@@ -831,10 +827,7 @@ and signatureToModuleRuntimeRepresentation =
     let (dl, fl) = dependenciesAndFields |> List.split;
     (dl |> List.concat, fl |> List.concat);
   };
-  (
-    dependencies,
-    config.modulesAsObjects ? Object(Closed, fields) : Record(fields),
-  );
+  (dependencies, Object(Closed, fields));
 };
 
 let translateTypeExprFromTypes =

--- a/src/TypeEnv.re
+++ b/src/TypeEnv.re
@@ -20,7 +20,7 @@ and entry =
   | Type(string);
 
 let createTypeEnv = (~name, parent) => {
-  let moduleItem = Runtime.moduleItemGen() |> Runtime.newModuleItem(~name);
+  let moduleItem = Runtime.newModuleItem(~name);
   {
     componentModuleItem: moduleItem,
     map: StringMap.empty,


### PR DESCRIPTION
There's a lot of code to deal with different runtime representations across versions of the compiler.

This disappears when supporting bs-platform 8.2 or newer.