### PR TITLE
Support "suffix" from `bsconfig.json` to specify the extension used by the compiler.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,5 @@
 # master
+- Add support for different file extensions using the `suffix` configuration from `bsconfig.json`.
 
 # 3.45.0
 - Only support bs-platform `8.2.0` or newer.

--- a/src/Config_.re
+++ b/src/Config_.re
@@ -38,6 +38,7 @@ type config = {
   reasonReactPath: string,
   shimsMap: ModuleNameMap.t(ModuleName.t),
   sources: option(Ext_json_types.t),
+  suffix: string,
 };
 
 let default = {
@@ -60,6 +61,7 @@ let default = {
   reasonReactPath: "reason-react/src/ReasonReact.js",
   shimsMap: ModuleNameMap.empty,
   sources: None,
+  suffix: "",
 };
 
 let bsPlatformLib = (~config) =>
@@ -259,6 +261,13 @@ let readConfig = (~bsVersion, ~getBsConfigFile, ~namespace) => {
       | _ => default.namespace
       };
 
+    let suffix =
+      switch (bsconf |> getStringOption("suffix")) {
+      | Some(".bs.js") => ".bs"
+      | Some(s) => s
+      | _ => ".bs"
+      };
+
     let bsDependencies =
       switch (bsconf |> getOpt("bs-dependencies")) {
       | Some(Arr({content})) =>
@@ -283,6 +292,7 @@ let readConfig = (~bsVersion, ~getBsConfigFile, ~namespace) => {
     {
       bsCurryPath,
       bsDependencies,
+      suffix,
       emitFlowAny: false,
       emitImportCurry: false,
       emitImportPropTypes: false,

--- a/src/EmitJs.re
+++ b/src/EmitJs.re
@@ -527,7 +527,7 @@ let rec emitCodeItem =
     let importPath =
       fileName
       |> ModuleResolver.resolveModule(
-           ~importExtension=".bs",
+           ~importExtension=config.suffix,
            ~outputFileRelative,
            ~resolver,
            ~useBsDependencies=false,
@@ -689,7 +689,7 @@ let rec emitCodeItem =
     let importPath =
       fileName
       |> ModuleResolver.resolveModule(
-           ~importExtension=".bs",
+           ~importExtension=config.suffix,
            ~outputFileRelative,
            ~resolver,
            ~useBsDependencies=false,


### PR DESCRIPTION
Fixes https://github.com/rescript-association/genType/issues/521.