### PR TITLE
Fix Flow error suppression codes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,5 @@
 # master
+- Flow: use explicit suppression codes.
 
 # 4.3.0
 - TypeScript: type children of imported components as `React.ReactNode` instead of `JSX.Element`.

--- a/examples/commonjs-react-example/src/Hooks.gen.js
+++ b/examples/commonjs-react-example/src/Hooks.gen.js
@@ -5,7 +5,7 @@
  */
 /* eslint-disable */
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 const HooksBS = require('./Hooks.bs');
 
 export type vehicle = {| +name: string |};

--- a/examples/commonjs-react-example/src/TestEmitInnerModules.gen.js
+++ b/examples/commonjs-react-example/src/TestEmitInnerModules.gen.js
@@ -5,7 +5,7 @@
  */
 /* eslint-disable */
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 const TestEmitInnerModulesBS = require('./TestEmitInnerModules.bs');
 
 const Inner_x: number = TestEmitInnerModulesBS.Inner.x;;

--- a/examples/commonjs-react-example/src/index.js
+++ b/examples/commonjs-react-example/src/index.js
@@ -16,5 +16,5 @@ const App = () => (
 );
 App.displayName = "ExampleInteropRoot";
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 ReactDOM.render(React.createElement(App), document.getElementById("index"));

--- a/examples/commonjs-react-example/src/shims/ReactShim.shim.js
+++ b/examples/commonjs-react-example/src/shims/ReactShim.shim.js
@@ -12,17 +12,17 @@ export type element = React.Node;
 
 export type component<t> = React.ComponentType<t>;
 
-// $FlowExpectedError: Reason checked type sufficiently.
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
 export opaque type componentSpec = any;
 
-// $FlowExpectedError: Reason checked type sufficiently.
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
 export opaque type noRetainedProps = any;
 
-// $FlowExpectedError: Reason checked type sufficiently.
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
 export opaque type actionless = any;
 
-// $FlowExpectedError: Reason checked type sufficiently.
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
 export opaque type stateless = any;
 
-// $FlowExpectedError: Reason checked type sufficiently.
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
 export opaque type reactRef = any;

--- a/examples/commonjs-react-example/src/shims/ReactShim.shim.js
+++ b/examples/commonjs-react-example/src/shims/ReactShim.shim.js
@@ -12,17 +12,17 @@ export type element = React.Node;
 
 export type component<t> = React.ComponentType<t>;
 
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently.
 export opaque type componentSpec = any;
 
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently.
 export opaque type noRetainedProps = any;
 
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently.
 export opaque type actionless = any;
 
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently.
 export opaque type stateless = any;
 
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently.
 export opaque type reactRef = any;

--- a/examples/commonjs-react-example/src/shims/ReasonPervasives.shim.js
+++ b/examples/commonjs-react-example/src/shims/ReasonPervasives.shim.js
@@ -6,7 +6,7 @@
 export opaque type SafeReasonValueNotExportedToFlow = mixed;
 'use strict';
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 const $$Array = require('bs-platform/lib/js/array');
 
 export opaque type EmptyList = mixed;

--- a/examples/flow-react-example/.flowconfig
+++ b/examples/flow-react-example/.flowconfig
@@ -5,6 +5,7 @@
 [libs]
 
 [lints]
+unclear-type=warn
 untyped-type-import=error
 
 [options]

--- a/examples/flow-react-example/src/AutoAnnotate.gen.js
+++ b/examples/flow-react-example/src/AutoAnnotate.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // $FlowExpectedError[untyped-import]: Reason checked type sufficiently

--- a/examples/flow-react-example/src/AutoAnnotate.gen.js
+++ b/examples/flow-react-example/src/AutoAnnotate.gen.js
@@ -4,13 +4,13 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as Curry from 'rescript/lib/es6/curry.js';
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as AutoAnnotateBS from './AutoAnnotate.bs';
 
 // flowlint-next-line nonstrict-import:off

--- a/examples/flow-react-example/src/Component2.gen.js
+++ b/examples/flow-react-example/src/Component2.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // $FlowExpectedError[untyped-import]: Reason checked type sufficiently

--- a/examples/flow-react-example/src/Component2.gen.js
+++ b/examples/flow-react-example/src/Component2.gen.js
@@ -4,10 +4,10 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as Component2BS from './Component2.bs';
 
 export type variant = 

--- a/examples/flow-react-example/src/FirstClassModules.gen.js
+++ b/examples/flow-react-example/src/FirstClassModules.gen.js
@@ -5,7 +5,7 @@
  */
 /* eslint-disable */
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as FirstClassModulesBS from './FirstClassModules.bs';
 
 export const firstClassModule: {|

--- a/examples/flow-react-example/src/Hooks.gen.js
+++ b/examples/flow-react-example/src/Hooks.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // $FlowExpectedError[untyped-import]: Reason checked type sufficiently

--- a/examples/flow-react-example/src/Hooks.gen.js
+++ b/examples/flow-react-example/src/Hooks.gen.js
@@ -4,16 +4,16 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as React from 'react';
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as Curry from 'rescript/lib/es6/curry.js';
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as HooksBS from './Hooks.bs';
 
 export type vehicle = {| +name: string |};

--- a/examples/flow-react-example/src/ImportHooks.gen.js
+++ b/examples/flow-react-example/src/ImportHooks.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // flowlint-next-line nonstrict-import:off

--- a/examples/flow-react-example/src/ImportHooks.gen.js
+++ b/examples/flow-react-example/src/ImportHooks.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
 // flowlint-next-line nonstrict-import:off

--- a/examples/flow-react-example/src/LetWithType.gen.js
+++ b/examples/flow-react-example/src/LetWithType.gen.js
@@ -5,7 +5,7 @@
  */
 /* eslint-disable */
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as LetWithTypeBS from './LetWithType.bs';
 
 export opaque type style = mixed;

--- a/examples/flow-react-example/src/Marcel1.gen.js
+++ b/examples/flow-react-example/src/Marcel1.gen.js
@@ -5,7 +5,7 @@
  */
 /* eslint-disable */
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as Marcel1BS from './Marcel1.bs';
 
 export type M_t = {| +name: string, +surname: string |};

--- a/examples/flow-react-example/src/Object.gen.js
+++ b/examples/flow-react-example/src/Object.gen.js
@@ -5,7 +5,7 @@
  */
 /* eslint-disable */
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as ObjectBS from './Object.bs';
 
 export type openObject<a> = { +foo: number, ... };

--- a/examples/flow-react-example/src/Object2.gen.js
+++ b/examples/flow-react-example/src/Object2.gen.js
@@ -5,7 +5,7 @@
  */
 /* eslint-disable */
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as Object2BS from './Object2.bs';
 
 export type openObject<a> = { +foo: number, ... };

--- a/examples/flow-react-example/src/OnClick2.gen.js
+++ b/examples/flow-react-example/src/OnClick2.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // $FlowExpectedError[untyped-import]: Reason checked type sufficiently

--- a/examples/flow-react-example/src/OnClick2.gen.js
+++ b/examples/flow-react-example/src/OnClick2.gen.js
@@ -4,10 +4,10 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as OnClick2BS from './OnClick2.bs';
 
 export type Props = {| +onClick: (SyntheticMouseEvent<$any>) => void |};

--- a/examples/flow-react-example/src/Opaque.gen.js
+++ b/examples/flow-react-example/src/Opaque.gen.js
@@ -5,7 +5,7 @@
  */
 /* eslint-disable */
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as OpaqueBS from './Opaque.bs';
 
 export opaque type t = mixed;

--- a/examples/flow-react-example/src/Records.gen.js
+++ b/examples/flow-react-example/src/Records.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // $FlowExpectedError[untyped-import]: Reason checked type sufficiently

--- a/examples/flow-react-example/src/Records.gen.js
+++ b/examples/flow-react-example/src/Records.gen.js
@@ -4,13 +4,13 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as Curry from 'rescript/lib/es6/curry.js';
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as RecordsBS from './Records.bs';
 
 import type {weekday as Types_weekday} from './Types.gen';

--- a/examples/flow-react-example/src/References.gen.js
+++ b/examples/flow-react-example/src/References.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // $FlowExpectedError[untyped-import]: Reason checked type sufficiently

--- a/examples/flow-react-example/src/References.gen.js
+++ b/examples/flow-react-example/src/References.gen.js
@@ -4,13 +4,13 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as Curry from 'rescript/lib/es6/curry.js';
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as ReferencesBS from './References.bs';
 
 export opaque type R_t<a> = mixed;

--- a/examples/flow-react-example/src/ShadowedValuesInModules.gen.js
+++ b/examples/flow-react-example/src/ShadowedValuesInModules.gen.js
@@ -5,7 +5,7 @@
  */
 /* eslint-disable */
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as ShadowedValuesInModulesBS from './ShadowedValuesInModules.bs';
 
 export const Nested_M_a: number = ShadowedValuesInModulesBS.Nested.M.a;

--- a/examples/flow-react-example/src/TestEmitInnerModules.gen.js
+++ b/examples/flow-react-example/src/TestEmitInnerModules.gen.js
@@ -5,7 +5,7 @@
  */
 /* eslint-disable */
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as TestEmitInnerModulesBS from './TestEmitInnerModules.bs';
 
 export const Inner_x: number = TestEmitInnerModulesBS.Inner.x;

--- a/examples/flow-react-example/src/TestImmutableArray.gen.js
+++ b/examples/flow-react-example/src/TestImmutableArray.gen.js
@@ -5,7 +5,7 @@
  */
 /* eslint-disable */
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as TestImmutableArrayBS from './TestImmutableArray.bs';
 
 export const testImmutableArrayGet: <T1>($ReadOnlyArray<T1>) => ?T1 = TestImmutableArrayBS.testImmutableArrayGet;

--- a/examples/flow-react-example/src/Tuples.gen.js
+++ b/examples/flow-react-example/src/Tuples.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // $FlowExpectedError[untyped-import]: Reason checked type sufficiently

--- a/examples/flow-react-example/src/Tuples.gen.js
+++ b/examples/flow-react-example/src/Tuples.gen.js
@@ -4,13 +4,13 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as Curry from 'rescript/lib/es6/curry.js';
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as TuplesBS from './Tuples.bs';
 
 export type coord = [number, number, ?number];

--- a/examples/flow-react-example/src/TypeExpansion.gen.js
+++ b/examples/flow-react-example/src/TypeExpansion.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // $FlowExpectedError[untyped-import]: Reason checked type sufficiently

--- a/examples/flow-react-example/src/TypeExpansion.gen.js
+++ b/examples/flow-react-example/src/TypeExpansion.gen.js
@@ -4,10 +4,10 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as TypeExpansionBS from './TypeExpansion.bs';
 
 import type {person as Tuples_person} from './Tuples.gen';

--- a/examples/flow-react-example/src/Types.gen.js
+++ b/examples/flow-react-example/src/Types.gen.js
@@ -4,13 +4,13 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
 // flowlint-next-line nonstrict-import:off
 import {foo as fooNotChecked} from './name-with-dashes';
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as Curry from 'rescript/lib/es6/curry.js';
 
 // In case of type error, check the type of 'foo' in 'Types.re' and './name-with-dashes'.
@@ -19,7 +19,7 @@ export const fooTypeChecked: (number) => number = fooNotChecked;
 // Export 'foo' early to allow circular import from the '.bs.js' file.
 export const foo: mixed = fooTypeChecked;
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 const TypesBS = require('./Types.bs');
 
 // flowlint-next-line nonstrict-import:off

--- a/examples/flow-react-example/src/Types.gen.js
+++ b/examples/flow-react-example/src/Types.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // flowlint-next-line nonstrict-import:off

--- a/examples/flow-react-example/src/Uncurried.gen.js
+++ b/examples/flow-react-example/src/Uncurried.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // $FlowExpectedError[untyped-import]: Reason checked type sufficiently

--- a/examples/flow-react-example/src/Uncurried.gen.js
+++ b/examples/flow-react-example/src/Uncurried.gen.js
@@ -4,13 +4,13 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as Curry from 'rescript/lib/es6/curry.js';
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as UncurriedBS from './Uncurried.bs';
 
 export type u0 = () => string;

--- a/examples/flow-react-example/src/Variants.gen.js
+++ b/examples/flow-react-example/src/Variants.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 const $$toJS508922110 = {"type_": "type", "module_": "module", "fortytwo": "42"};

--- a/examples/flow-react-example/src/Variants.gen.js
+++ b/examples/flow-react-example/src/Variants.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
 const $$toJS508922110 = {"type_": "type", "module_": "module", "fortytwo": "42"};
@@ -23,7 +23,7 @@ const $$toJS1061900109 = {"x": "x", "x2": "same"};
 
 const $$toRE1061900109 = {"x": "x", "same": "x2"};
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as VariantsBS from './Variants.bs';
 
 export type weekday = 

--- a/examples/flow-react-example/src/VariantsWithPayload.gen.js
+++ b/examples/flow-react-example/src/VariantsWithPayload.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 const $$toJS13337556 = {"0": "ARenamed"};

--- a/examples/flow-react-example/src/VariantsWithPayload.gen.js
+++ b/examples/flow-react-example/src/VariantsWithPayload.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
 const $$toJS13337556 = {"0": "ARenamed"};
@@ -19,7 +19,7 @@ const $$toJS435467058 = {"a": "a", "b": "bRenamed", "True": true, "Twenty": 20, 
 
 const $$toRE435467058 = {"a": "a", "bRenamed": "b", "true": "True", "20": "Twenty", "0.5": "Half"};
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as VariantsWithPayloadBS from './VariantsWithPayload.bs';
 
 export type payload = {| +x: number, +y?: string |};

--- a/examples/flow-react-example/src/components/Navigator.gen.js
+++ b/examples/flow-react-example/src/components/Navigator.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // $FlowExpectedError[untyped-import]: Reason checked type sufficiently

--- a/examples/flow-react-example/src/components/Navigator.gen.js
+++ b/examples/flow-react-example/src/components/Navigator.gen.js
@@ -4,13 +4,13 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as Curry from 'rescript/lib/es6/curry.js';
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as NavigatorBS from './Navigator.bs';
 
 // flowlint-next-line nonstrict-import:off

--- a/examples/flow-react-example/src/components/RenameProps.gen.js
+++ b/examples/flow-react-example/src/components/RenameProps.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // $FlowExpectedError[untyped-import]: Reason checked type sufficiently

--- a/examples/flow-react-example/src/components/RenameProps.gen.js
+++ b/examples/flow-react-example/src/components/RenameProps.gen.js
@@ -4,13 +4,13 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as Curry from 'rescript/lib/es6/curry.js';
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as RenamePropsBS from './RenameProps.bs';
 
 // flowlint-next-line nonstrict-import:off

--- a/examples/flow-react-example/src/interop/ImportJsValue.gen.js
+++ b/examples/flow-react-example/src/interop/ImportJsValue.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 // flowlint-next-line nonstrict-import:off

--- a/examples/flow-react-example/src/interop/ImportJsValue.gen.js
+++ b/examples/flow-react-example/src/interop/ImportJsValue.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
 // flowlint-next-line nonstrict-import:off
@@ -28,7 +28,7 @@ import {polymorphic as polymorphicNotChecked} from './MyMath';
 // flowlint-next-line nonstrict-import:off
 import {default as defaultNotChecked} from './MyMath';
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as Curry from 'rescript/lib/es6/curry.js';
 
 // In case of type error, check the type of 'round' in 'ImportJsValue.re' and './MyMath'.
@@ -86,7 +86,7 @@ export const defaultTypeChecked: number = defaultNotChecked;
 // Export '$$default' early to allow circular import from the '.bs.js' file.
 export const $$default: mixed = defaultTypeChecked;
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 const ImportJsValueBS = require('./ImportJsValue.bs');
 
 // flowlint-next-line nonstrict-import:off

--- a/examples/flow-react-example/src/interop/InteropRoot.js
+++ b/examples/flow-react-example/src/interop/InteropRoot.js
@@ -63,5 +63,5 @@ const App = () => (
 );
 App.displayName = "ExampleInteropRoot";
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 ReactDOM.render(React.createElement(App), document.getElementById("index"));

--- a/examples/flow-react-example/src/interop/MyMath.js
+++ b/examples/flow-react-example/src/interop/MyMath.js
@@ -1,6 +1,6 @@
 /* @flow strict */
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
 const ImportJsValue = require("./ImportJsValue.gen");

--- a/examples/flow-react-example/src/interop/MyMath.js
+++ b/examples/flow-react-example/src/interop/MyMath.js
@@ -1,6 +1,6 @@
 /* @flow strict */
 
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 const ImportJsValue = require("./ImportJsValue.gen");

--- a/examples/flow-react-example/src/nested/Nested.gen.js
+++ b/examples/flow-react-example/src/nested/Nested.gen.js
@@ -4,7 +4,7 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently
 type $any = any;
 
 const $$toRE552311971 = {"A": 0};

--- a/examples/flow-react-example/src/nested/Nested.gen.js
+++ b/examples/flow-react-example/src/nested/Nested.gen.js
@@ -4,12 +4,12 @@
  * @nolint
  */
 /* eslint-disable */
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 type $any = any;
 
 const $$toRE552311971 = {"A": 0};
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 import * as NestedBS from './Nested.bs';
 
 import type {variant as Component2_variant} from '../../src/Component2.gen';

--- a/examples/flow-react-example/src/shims/ReactShim.shim.js
+++ b/examples/flow-react-example/src/shims/ReactShim.shim.js
@@ -12,20 +12,20 @@ export type element = React.Node;
 
 export type component<t> = React.ComponentType<t>;
 
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently.
 export opaque type componentSpec = any;
 
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently.
 export opaque type noRetainedProps = any;
 
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently.
 export opaque type actionless = any;
 
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently.
 export opaque type stateless = any;
 
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently.
 export opaque type reactRef = any;
 
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
+// $FlowExpectedError[unclear-type]: Reason checked type sufficiently.
 export opaque type ref = any;

--- a/examples/flow-react-example/src/shims/ReactShim.shim.js
+++ b/examples/flow-react-example/src/shims/ReactShim.shim.js
@@ -12,20 +12,20 @@ export type element = React.Node;
 
 export type component<t> = React.ComponentType<t>;
 
-// $FlowExpectedError: Reason checked type sufficiently.
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
 export opaque type componentSpec = any;
 
-// $FlowExpectedError: Reason checked type sufficiently.
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
 export opaque type noRetainedProps = any;
 
-// $FlowExpectedError: Reason checked type sufficiently.
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
 export opaque type actionless = any;
 
-// $FlowExpectedError: Reason checked type sufficiently.
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
 export opaque type stateless = any;
 
-// $FlowExpectedError: Reason checked type sufficiently.
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
 export opaque type reactRef = any;
 
-// $FlowExpectedError: Reason checked type sufficiently.
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently.
 export opaque type ref = any;

--- a/examples/flow-react-example/src/shims/ReasonPervasives.shim.js
+++ b/examples/flow-react-example/src/shims/ReasonPervasives.shim.js
@@ -6,7 +6,7 @@
 export opaque type SafeReasonValueNotExportedToFlow = mixed;
 'use strict';
 
-// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
+// $FlowExpectedError[cannot-resolve-module]: Reason checked type sufficiently
 const $$Array = require('bs-platform/lib/js/array');
 
 export opaque type EmptyList = mixed;

--- a/examples/flow-react-example/src/shims/ReasonPervasives.shim.js
+++ b/examples/flow-react-example/src/shims/ReasonPervasives.shim.js
@@ -6,7 +6,7 @@
 export opaque type SafeReasonValueNotExportedToFlow = mixed;
 'use strict';
 
-// $FlowExpectedError: Reason checked type sufficiently
+// $FlowExpectedError[untyped-import]: Reason checked type sufficiently
 const $$Array = require('bs-platform/lib/js/array');
 
 export opaque type EmptyList = mixed;

--- a/src/EmitType.ml
+++ b/src/EmitType.ml
@@ -1,7 +1,7 @@
 open GenTypeCommon
 
 let flowExpectedError =
-  "// $FlowExpectedError: Reason checked type sufficiently\n"
+  "// $FlowExpectedError[untyped-import]: Reason checked type sufficiently\n"
 
 let flowTypeAny = flowExpectedError ^ "type $any = any;\n"
 

--- a/src/EmitType.ml
+++ b/src/EmitType.ml
@@ -1,9 +1,16 @@
 open GenTypeCommon
 
-let flowExpectedError =
-  "// $FlowExpectedError[untyped-import]: Reason checked type sufficiently\n"
+type flowError = UntypedImport | UnclearType
 
-let flowTypeAny = flowExpectedError ^ "type $any = any;\n"
+let flowExpectedError flowError =
+  let errorStr =
+    match flowError with
+    | UntypedImport -> "untyped-import"
+    | UnclearType -> "unclear-type"
+  in
+  "// $FlowExpectedError[" ^ errorStr ^ "]: Reason checked type sufficiently\n"
+
+let flowTypeAny = flowExpectedError UnclearType ^ "type $any = any;\n"
 
 let fileHeader ~config ~sourceFile =
   let makeHeader ~lines =
@@ -81,9 +88,7 @@ let typeReactContext ~config ~type_ =
   |> ident ~builtin:true ~typeArgs:[type_]
 
 let typeReactElementFlow = ident ~builtin:true "React$Node"
-
 let typeReactElementTypeScript = ident ~builtin:true "JSX.Element"
-
 let typeReactChildTypeScript = ident ~builtin:true "React.ReactNode"
 
 let typeReactElement ~config =
@@ -369,7 +374,6 @@ let emitExportConst_ ~early ?(comment = "") ~config ?(docString = "") ~emitters
        ~emitters
 
 let emitExportConst = emitExportConst_ ~early:false
-
 let emitExportConstEarly = emitExportConst_ ~early:true
 
 let emitExportDefault ~emitters ~config name =
@@ -473,7 +477,7 @@ let emitRequire ~importedValueOrComponent ~early ~emitters ~config ~moduleName
         match early with
         | true -> "// flowlint-next-line nonstrict-import:off\n"
         | false -> "")
-      | false -> flowExpectedError)
+      | false -> flowExpectedError UntypedImport)
     | Untyped -> ""
   in
   match config.module_ with


### PR DESCRIPTION
Flow requires error suppression codes (see: https://flow.org/en/docs/errors/). It returns the following warning without them:

```
Warning ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/abacus-backoffice/src/cats/Test.gen.js:8:1

Suppression is missing a code. Please update this suppression to use an error code: $FlowFixMe[untyped-import]

      5│  */
      6│ /* eslint-disable */
      7│
      8│ // $FlowExpectedError: Reason checked type sufficiently
      9│ import * as TestBS from './Test.bs';
     10│
     11│ export type Props = {| +name?: string, +children: React$Node |};

Found 1 warning
```